### PR TITLE
Indicate Tech Preview on OIDC v2 sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ MATR Wallet Toolkit React Native / [Exports](modules.md)
 - [Usage](#usage)
   - [Codec](#codec)
   - [Wallet](#wallet)
-  - [Retrieving credentials via OIDC (Tech Preview)](#retrieving-credentials-via-oidc)
-  - [Retrieving credentials via OpenId issuance (Tech Preview)](#retrieving-credentials-via-openid-issuance)
-  - [Handling a credential presentation request DidComm message (Tech Preview)](#handling-a-credential-presentation-request-didcomm-message)
+  - [Retrieving credentials via OIDC Bridge](#retrieving-credentials-via-oidc)
+  - [Retrieving credentials via OpenID issuance (Tech Preview)](#retrieving-credentials-via-openid-issuance)
+  - [Handling a credential presentation request DidComm message](#handling-a-credential-presentation-request-didcomm-message)
   - [Error handling](#error-handling)
 
 # Features
@@ -160,7 +160,7 @@ import { destroy } from "@mattrglobal/wallet-sdk-react-native";
 await wallet.destroy();
 ```
 
-## Retrieving credentials via OIDC (Tech Preview)
+## Retrieving credentials via OIDC Bridge
 
 Discover OIDC credential offer
 
@@ -235,7 +235,7 @@ if (verifyResult.isErr()) {
 const { credentialVerified, status } = verifyResult.value;
 ```
 
-## Retrieving credentials via openid issuance (Tech Preview)
+## Retrieving credentials via OpenID issuance (Tech Preview)
 
 Construct an offer
 
@@ -322,7 +322,7 @@ retrieveCredentialsResult.value.credentials.forEach(({ credential, format, did }
 });
 ```
 
-## Handling a credential presentation request DIDComm message (Tech Preview)
+## Handling a credential presentation request DIDComm message
 
 Open a presentation request DIDComm message
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MATTR Wallet Toolkit React Native / [Exports](modules.md)
   - [Codec](#codec)
   - [Wallet](#wallet)
   - [Retrieving credentials via OIDC Bridge](#retrieving-credentials-via-oidc)
-  - [Retrieving credentials via OpenID issuance (Tech Preview)](#retrieving-credentials-via-openid-issuance)
+  - [Retrieving credentials via OpenID4VCI issuance (Tech Preview)](#retrieving-credentials-via-openid-issuance)
   - [Handling a credential presentation request DidComm message](#handling-a-credential-presentation-request-didcomm-message)
   - [Error handling](#error-handling)
 
@@ -235,7 +235,7 @@ if (verifyResult.isErr()) {
 const { credentialVerified, status } = verifyResult.value;
 ```
 
-## Retrieving credentials via OpenID issuance (Tech Preview)
+## Retrieving credentials via OpenID4VCI issuance (Tech Preview)
 
 Construct an offer
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Mattr Wallet SDK React Native / [Exports](modules.md)
+MATR Wallet Toolkit React Native / [Exports](modules.md)
 
-# wallet-sdk-react-native
+# wallet-toolkit-react-native
 
 # Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MATR Wallet Toolkit React Native / [Exports](modules.md)
+MATTR Wallet Toolkit React Native / [Exports](modules.md)
 
 # wallet-toolkit-react-native
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ MATTR Wallet Toolkit React Native / [Exports](modules.md)
   - [Wallet](#wallet)
   - [Retrieving credentials via OIDC Bridge](#retrieving-credentials-via-oidc)
   - [Retrieving credentials via OpenID4VCI (Tech Preview)](#retrieving-credentials-via-openid4vci)
-  - [Handling a credential presentation request DidComm message](#handling-a-credential-presentation-request-didcomm-message)
+  - [Handling a credential presentation request DIDComm message](#handling-a-credential-presentation-request-didcomm-message)
   - [Error handling](#error-handling)
 
 # Features

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Mattr Wallet SDK React Native / [Exports](modules.md)
 - [Usage](#usage)
   - [Codec](#codec)
   - [Wallet](#wallet)
-  - [Retrieving credentials via OIDC](#retrieving-credentials-via-oidc)
-  - [Retrieving credentials via OpenId issuance](#retrieving-credentials-via-openid-issuance)
-  - [Handling a credential presentation request DidComm message](#handling-a-credential-presentation-request-didcomm-message)
+  - [Retrieving credentials via OIDC (Tech Preview)](#retrieving-credentials-via-oidc)
+  - [Retrieving credentials via OpenId issuance (Tech Preview)](#retrieving-credentials-via-openid-issuance)
+  - [Handling a credential presentation request DidComm message (Tech Preview)](#handling-a-credential-presentation-request-didcomm-message)
   - [Error handling](#error-handling)
 
 # Features
@@ -160,7 +160,7 @@ import { destroy } from "@mattrglobal/wallet-sdk-react-native";
 await wallet.destroy();
 ```
 
-## Retrieving credentials via OIDC
+## Retrieving credentials via OIDC (Tech Preview)
 
 Discover OIDC credential offer
 
@@ -235,7 +235,7 @@ if (verifyResult.isErr()) {
 const { credentialVerified, status } = verifyResult.value;
 ```
 
-## Retrieving credentials via openid issuance
+## Retrieving credentials via openid issuance (Tech Preview)
 
 Construct an offer
 
@@ -322,7 +322,7 @@ retrieveCredentialsResult.value.credentials.forEach(({ credential, format, did }
 });
 ```
 
-## Handling a credential presentation request DIDComm message
+## Handling a credential presentation request DIDComm message (Tech Preview)
 
 Open a presentation request DIDComm message
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MATTR Wallet Toolkit React Native / [Exports](modules.md)
   - [Codec](#codec)
   - [Wallet](#wallet)
   - [Retrieving credentials via OIDC Bridge](#retrieving-credentials-via-oidc)
-  - [Retrieving credentials via OpenID4VCI issuance (Tech Preview)](#retrieving-credentials-via-openid-issuance)
+  - [Retrieving credentials via OpenID4VCI (Tech Preview)](#retrieving-credentials-via-openid4vci)
   - [Handling a credential presentation request DidComm message](#handling-a-credential-presentation-request-didcomm-message)
   - [Error handling](#error-handling)
 
@@ -235,7 +235,7 @@ if (verifyResult.isErr()) {
 const { credentialVerified, status } = verifyResult.value;
 ```
 
-## Retrieving credentials via OpenID4VCI issuance (Tech Preview)
+## Retrieving credentials via OpenID4VCI (Tech Preview)
 
 Construct an offer
 


### PR DESCRIPTION
Wanted to update the readme ahead of our public MATTR Pi Product launch because there will be more visitors -- we should indicate the sections of the readme which are related to OpenID4VCI 2.0 and are currently only available in tech preview mode. We also want to start using "MATTR Wallet Toolkit" instead of "MATTR Wallet SDK" so updated to reflect that.